### PR TITLE
add User-Agent header to HTTP requests

### DIFF
--- a/stitch.c
+++ b/stitch.c
@@ -354,6 +354,7 @@ int main(int argc, char **argv) {
 
 				curl_easy_setopt(curl, CURLOPT_URL, url2);
 				curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+				curl_easy_setopt(curl, CURLOPT_USERAGENT, "tile-stitch/1.0.0");
 				curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
 				curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_receive);
 


### PR DESCRIPTION
This pull request adds a default User-Agent header to outgoing HTTP requests. The header ensures that certain map tile servers (such as Google's map tiles at `http://mt.google.com/vt/lyrs=s&x={x}&y={y}&z={z}`) do not refuse our requests.